### PR TITLE
Fix/bug/cms client/nested entry is not included in response

### DIFF
--- a/src/consts/cms.ts
+++ b/src/consts/cms.ts
@@ -1,1 +1,4 @@
 export const AssetKeys = ['thumbnail', 'avatar_image', 'img_icon'];
+
+export const DEPTH_REF_BY_COMPANY = 3;
+export const DEPTH_REF_BY_PERSONAL_DEVELOPMENT = 2;

--- a/src/pages/career.tsx
+++ b/src/pages/career.tsx
@@ -8,6 +8,8 @@ import { getEntries } from '@/utils/cmsUtils';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import { isNull } from 'lodash';
 import CompanyDetailView from '@/features/company/CompanyDetailview';
+import { DEPTH_REF_BY_COMPANY } from '@/consts/cms';
+import { ContentGetQueryParam } from '@/types/cms.type';
 
 type CareerPageP = {
   companies: ComponentProps<typeof CompanyDetailView>['entries'] | null;
@@ -28,7 +30,10 @@ export default CareerPage;
 export const getStaticProps: GetStaticProps = async (
   context
 ): Promise<GetStaticPropsResult<CareerPageP>> => {
-  const companies = await getEntries<ICompanyFields>('faq');
+  const companies = await getEntries<ICompanyFields, ContentGetQueryParam>(
+    'company',
+    { include: DEPTH_REF_BY_COMPANY }
+  );
   const futureGoals = await getEntries<IFutureGoalFields>('future_goal');
 
   return {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -11,6 +11,8 @@ import { getEntries } from '@/utils/cmsUtils';
 // import { Entry } from 'contentful';
 import HomeView, { HomeViewProps } from '@/features/home/HomeView';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import { DEPTH_REF_BY_COMPANY } from '@/consts/cms';
+import { ContentGetQueryParam } from '@/types/cms.type';
 
 type HomePageProps = HomeViewProps;
 
@@ -22,13 +24,22 @@ export const getStaticProps: GetStaticProps = async (
   context
 ): Promise<GetStaticPropsResult<HomePageProps>> => {
   const profile = await getEntries<IProfileFields>('profile');
-  const companies = await getEntries<ICompanyFields>('company');
-  const faqs = await getEntries<IFaqFields>('faq');
-  const personalDevelopments = await getEntries<IPersonalDevelopmentFields>(
-    'personal_development'
+  const companies = await getEntries<ICompanyFields, ContentGetQueryParam>(
+    'company',
+    { include: DEPTH_REF_BY_COMPANY }
   );
+  const faqs = await getEntries<IFaqFields>('faq');
+  const personalDevelopments = await getEntries<
+    IPersonalDevelopmentFields,
+    ContentGetQueryParam
+  >('personal_development', { include: 2 });
   const skillSets = await getEntries<ISkillsetFields>('skillset');
   const futureGoals = await getEntries<IFutureGoalFields>('future_goal');
+
+  console.log(
+    'PERS DEV > Dev env >',
+    personalDevelopments?.[0].development_env?.fields.languages
+  );
 
   return {
     props: {

--- a/src/pages/personal_development.tsx
+++ b/src/pages/personal_development.tsx
@@ -5,6 +5,8 @@ import { getEntries } from '@/utils/cmsUtils';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import { isNull } from 'lodash';
 import PersonalDevelopmentListView from '@/features/personal_development/PersonalDevelopmentListView';
+import { DEPTH_REF_BY_PERSONAL_DEVELOPMENT } from '@/consts/cms';
+import { ContentGetQueryParam } from '@/types/cms.type';
 
 type PersonalDevelopmentPageP = {
   personalDevelopments:
@@ -25,9 +27,10 @@ export default PersonalDevelopmentPage;
 export const getStaticProps: GetStaticProps = async (
   context
 ): Promise<GetStaticPropsResult<PersonalDevelopmentPageP>> => {
-  const personalDevelopments = await getEntries<IPersonalDevelopmentFields>(
-    'personal_development'
-  );
+  const personalDevelopments = await getEntries<
+    IPersonalDevelopmentFields,
+    ContentGetQueryParam
+  >('personal_development', { include: DEPTH_REF_BY_PERSONAL_DEVELOPMENT });
 
   return {
     props: {

--- a/src/types/cms.type.ts
+++ b/src/types/cms.type.ts
@@ -90,3 +90,5 @@ export type EntityORFieldOrUndefined =
   | EntryField
   | Exclude<IEntry, ICareer>
   | undefined;
+
+export type ContentGetQueryParam = { include?: number };


### PR DESCRIPTION
cms clientで別の content typeを参照するフィールドを持つ content を取得したときに、孫階層にネストされたcontent がレスポンスに含まれていない